### PR TITLE
Require a Dockerfile to reproduce the provided shim EFI binaries

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -8,6 +8,7 @@ Make sure you have provided the following information:
  - [ ] any extra patches to shim via your own git tree or as files
  - [ ] any extra patches to grub via your own git tree or as files
  - [ ] build logs
+ - [ ] a Dockerfile to reproduce the build of the provided shim EFI binaries
 
 
 ###### What organization or people are asking to have this signed:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ apply. Please describe your strategy.
 
 -------------------------------------------------------------------------------
 What OS and toolchain must we use to reproduce this build?  Include where to find it, etc.  We're going to try to reproduce your build as close as possible to verify that it's really a build of the source tree you tell us it is, so these need to be fairly thorough. At the very least include the specific versions of gcc, binutils, and gnu-efi which were used, and where to find those binaries.
-If possible, provide a Dockerfile that rebuilds the shim.
+If the shim binaries can't be reproduced using the provided Dockerfile, please explain why that's the case and the differences would be.
 -------------------------------------------------------------------------------
 [your text here]
 


### PR DESCRIPTION
This makes reproducing the binary easier for people reviewing the submissions.