### PR TITLE
Make formatting of README and ISSUE_TEMPLATE match

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -10,95 +10,122 @@ Make sure you have provided the following information:
  - [ ] build logs
  - [ ] a Dockerfile to reproduce the build of the provided shim EFI binaries
 
-
-###### What organization or people are asking to have this signed:
+-------------------------------------------------------------------------------
+### What organization or people are asking to have this signed:
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### What product or service is this for:
+-------------------------------------------------------------------------------
+### What product or service is this for:
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### Please create your shim binaries starting with the 15.4 shim release tar file:
-###### https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2
-###### This matches https://github.com/rhboot/shim/releases/tag/15.4 and contains
-###### the appropriate gnu-efi source.
-###### Please confirm this as the origin your shim.
+-------------------------------------------------------------------------------
+### Please create your shim binaries starting with the 15.4 shim release tar file:  https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2
+### This matches https://github.com/rhboot/shim/releases/tag/15.4 and contains the appropriate gnu-efi source.
+### Please confirm this as the origin your shim.
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### What's the justification that this really does need to be signed for the whole world to be able to boot it:
+-------------------------------------------------------------------------------
+### What's the justification that this really does need to be signed for the whole world to be able to boot it:
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### How do you manage and protect the keys used in your SHIM?
+-------------------------------------------------------------------------------
+### How do you manage and protect the keys used in your SHIM?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### Do you use EV certificates as embedded certificates in the SHIM?
+-------------------------------------------------------------------------------
+### Do you use EV certificates as embedded certificates in the SHIM?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### If you use new vendor_db functionality, are any hashes allow-listed, and if yes: for what binaries ?
+-------------------------------------------------------------------------------
+### If you use new vendor_db functionality, are any hashes allow-listed, and if yes: for what binaries ?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### Is kernel upstream commit 75b0cea7bf307f362057cc778efe89af4c615354 present in your kernel, if you boot chain includes a Linux kernel ?
+-------------------------------------------------------------------------------
+### Is kernel upstream commit 75b0cea7bf307f362057cc778efe89af4c615354 present in your kernel, if you boot chain includes a Linux kernel ?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### if SHIM is loading GRUB2 bootloader, are CVEs CVE-2020-14372,
-###### CVE-2020-25632, CVE-2020-25647, CVE-2020-27749, CVE-2020-27779,
-###### CVE-2021-20225, CVE-2021-20233, CVE-2020-10713, CVE-2020-14308,
-###### CVE-2020-14309, CVE-2020-14310, CVE-2020-14311, CVE-2020-15705,
-###### ( July 2020 grub2 CVE list + March 2021 grub2 CVE list )
-###### and if you are shipping the shim_lock module CVE-2021-3418
-###### fixed ?
+-------------------------------------------------------------------------------
+### if SHIM is loading GRUB2 bootloader, are CVEs CVE-2020-14372, CVE-2020-25632, CVE-2020-25647, CVE-2020-27749, CVE-2020-27779, CVE-2021-20225, CVE-2021-20233, CVE-2020-10713, CVE-2020-14308, CVE-2020-14309, CVE-2020-14310, CVE-2020-14311, CVE-2020-15705, ( July 2020 grub2 CVE list + March 2021 grub2 CVE list ) and if you are shipping the shim_lock module CVE-2021-3418 fixed ?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### "Please specifically confirm that you add a vendor specific SBAT entry for SBAT header in each binary that supports SBAT metadata
-###### ( grub2, fwupd, fwupdate, shim + all child shim binaries )" to shim review doc ?
-###### Please provide exact SBAT entries for all SBAT binaries you are booting or planning to boot directly through shim
-###### Where your code is only slightly modified from an upstream vendor's, please also preserve their SBAT entries to simplify revocation
+-------------------------------------------------------------------------------
+### "Please specifically confirm that you add a vendor specific SBAT entry for SBAT header in each binary that supports SBAT metadata ( grub2, fwupd, fwupdate, shim + all child shim binaries )" to shim review doc ?
+### Please provide exact SBAT entries for all SBAT binaries you are booting or planning to boot directly through shim
+### Where your code is only slightly modified from an upstream vendor's, please also preserve their SBAT entries to simplify revocation.
+-------------------------------------------------------------------------------
 `[your text here]`
 
-##### Were your old SHIM hashes provided to Microsoft ?
+-------------------------------------------------------------------------------
+### Were your old SHIM hashes provided to Microsoft ?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-##### Did you change your certificate strategy, so that affected by CVE-2020-14372, CVE-2020-25632, CVE-2020-25647, CVE-2020-27749,
-##### CVE-2020-27779, CVE-2021-20225, CVE-2021-20233, CVE-2020-10713,
-##### CVE-2020-14308, CVE-2020-14309, CVE-2020-14310, CVE-2020-14311, CVE-2020-15705 ( July 2020 grub2 CVE list + March 2021 grub2 CVE list )
-##### grub2 bootloaders can not be verified ?
+-------------------------------------------------------------------------------
+### Did you change your certificate strategy, so that affected by CVE-2020-14372, CVE-2020-25632, CVE-2020-25647, CVE-2020-27749, CVE-2020-27779, CVE-2021-20225, CVE-2021-20233, CVE-2020-10713, CVE-2020-14308, CVE-2020-14309, CVE-2020-14310, CVE-2020-14311, CVE-2020-15705 ( July 2020 grub2 CVE list + March 2021 grub2 CVE list ) grub2 bootloaders can not be verified ?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-##### What exact implementation of Secureboot in grub2 ( if this is your bootloader ) you have ?
-##### * Upstream grub2 shim_lock verifier or * Downstream RHEL/Fedora/Debian/Canonical like implementation ?
+-------------------------------------------------------------------------------
+### What exact implementation of Secureboot in grub2 ( if this is your bootloader ) you have ?
+### * Upstream grub2 shim_lock verifier or * Downstream RHEL/Fedora/Debian/Canonical like implementation ?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-##### Which modules are built into your signed grub image?
+-------------------------------------------------------------------------------
+### Which modules are built into your signed grub image?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### What is the origin and full version number of your bootloader (GRUB or other)?
+-------------------------------------------------------------------------------
+### What is the origin and full version number of your bootloader (GRUB or other)?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### If your SHIM launches any other components, please provide further details on what is launched
+-------------------------------------------------------------------------------
+### If your SHIM launches any other components, please provide further details on what is launched
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### If your GRUB2 launches any other binaries that are not Linux kernel in SecureBoot mode,
-###### please provide further details on what is launched and how it enforces Secureboot lockdown
+-------------------------------------------------------------------------------
+### If your GRUB2 launches any other binaries that are not Linux kernel in SecureBoot mode, please provide further details on what is launched and how it enforces Secureboot lockdown
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### If you are re-using a previously used (CA) certificate, you
-###### will need to add the hashes of the previous GRUB2 binaries
-###### exposed to the CVEs to vendor_dbx in shim in order to prevent
-###### GRUB2 from being able to chainload those older GRUB2 binaries. If
-###### you are changing to a new (CA) certificate, this does not
-###### apply. Please describe your strategy.
+-------------------------------------------------------------------------------
+### If you are re-using a previously used (CA) certificate, you will need to add the hashes of the previous GRUB2 binaries exposed to the CVEs to vendor_dbx in shim in order to prevent GRUB2 from being able to chainload those older GRUB2 binaries. If you are changing to a new (CA) certificate, this does not apply. Please describe your strategy.
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### How do the launched components prevent execution of unauthenticated code?
+-------------------------------------------------------------------------------
+### How do the launched components prevent execution of unauthenticated code?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### Does your SHIM load any loaders that support loading unsigned kernels (e.g. GRUB)?
+-------------------------------------------------------------------------------
+### Does your SHIM load any loaders that support loading unsigned kernels (e.g. GRUB)?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### What kernel are you using? Which patches does it includes to enforce Secure Boot?
+-------------------------------------------------------------------------------
+### What kernel are you using? Which patches does it includes to enforce Secure Boot?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### What changes were made since your SHIM was last signed?
+-------------------------------------------------------------------------------
+### What changes were made since your SHIM was last signed?
+-------------------------------------------------------------------------------
 `[your text here]`
 
-###### What is the SHA256 hash of your final SHIM binary?
+-------------------------------------------------------------------------------
+### What is the SHA256 hash of your final SHIM binary?
+-------------------------------------------------------------------------------
 `[your text here]`

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -11,12 +11,12 @@ Make sure you have provided the following information:
  - [ ] a Dockerfile to reproduce the build of the provided shim EFI binaries
 
 -------------------------------------------------------------------------------
-### What organization or people are asking to have this signed:
+### What organization or people are asking to have this signed?
 -------------------------------------------------------------------------------
 `[your text here]`
 
 -------------------------------------------------------------------------------
-### What product or service is this for:
+### What product or service is this for?
 -------------------------------------------------------------------------------
 `[your text here]`
 
@@ -28,7 +28,7 @@ Make sure you have provided the following information:
 `[your text here]`
 
 -------------------------------------------------------------------------------
-### What's the justification that this really does need to be signed for the whole world to be able to boot it:
+### What's the justification that this really does need to be signed for the whole world to be able to boot it?
 -------------------------------------------------------------------------------
 `[your text here]`
 
@@ -43,7 +43,8 @@ Make sure you have provided the following information:
 `[your text here]`
 
 -------------------------------------------------------------------------------
-### If you use new vendor_db functionality, are any hashes allow-listed, and if yes: for what binaries ?
+### If you use new vendor_db functionality, are any hashes allow-listed?
+### If yes: for what binaries?
 -------------------------------------------------------------------------------
 `[your text here]`
 
@@ -91,17 +92,18 @@ Make sure you have provided the following information:
 `[your text here]`
 
 -------------------------------------------------------------------------------
-### If your SHIM launches any other components, please provide further details on what is launched
+### If your SHIM launches any other components, please provide further details on what is launched.
 -------------------------------------------------------------------------------
 `[your text here]`
 
 -------------------------------------------------------------------------------
-### If your GRUB2 launches any other binaries that are not Linux kernel in SecureBoot mode, please provide further details on what is launched and how it enforces Secureboot lockdown
+### If your GRUB2 launches any other binaries that are not the Linux kernel in SecureBoot mode, please provide further details on what is launched and how it enforces Secureboot lockdown.
 -------------------------------------------------------------------------------
 `[your text here]`
 
 -------------------------------------------------------------------------------
-### If you are re-using a previously used (CA) certificate, you will need to add the hashes of the previous GRUB2 binaries exposed to the CVEs to vendor_dbx in shim in order to prevent GRUB2 from being able to chainload those older GRUB2 binaries. If you are changing to a new (CA) certificate, this does not apply. Please describe your strategy.
+### If you are re-using a previously used (CA) certificate, you will need to add the hashes of the previous GRUB2 binaries exposed to the CVEs to vendor_dbx in shim in order to prevent GRUB2 from being able to chainload those older GRUB2 binaries. If you are changing to a new (CA) certificate, this does not apply.
+### Please describe your strategy.
 -------------------------------------------------------------------------------
 `[your text here]`
 

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ your part.
 Here's the template:
 
 -------------------------------------------------------------------------------
-What organization or people are asking to have this signed:
+### What organization or people are asking to have this signed:
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-What product or service is this for:
+### What product or service is this for:
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-What's the justification that this really does need to be signed for the whole world to be able to boot it:
+### What's the justification that this really does need to be signed for the whole world to be able to boot it:
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-Who is the primary contact for security updates, etc.
+### Who is the primary contact for security updates, etc.
 -------------------------------------------------------------------------------
 - Name:
 - Position:
@@ -45,7 +45,7 @@ like keyserver.ubuntu.com, and preferably have signatures that are reasonably
 well known in the Linux community.)
 
 -------------------------------------------------------------------------------
-Who is the secondary contact for security updates, etc.
+### Who is the secondary contact for security updates, etc.
 -------------------------------------------------------------------------------
 - Name:
 - Position:
@@ -57,47 +57,35 @@ like keyserver.ubuntu.com, and preferably have signatures that are reasonably
 well known in the Linux community.)
 
 -------------------------------------------------------------------------------
-Please create your shim binaries starting with the 15.4 shim release tar file:
-https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2
-
-This matches https://github.com/rhboot/shim/releases/tag/15.4 and contains
-the appropriate gnu-efi source.
+### Please create your shim binaries starting with the 15.4 shim release tar file: https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2
+### This matches https://github.com/rhboot/shim/releases/tag/15.4 and contains the appropriate gnu-efi source.
 -------------------------------------------------------------------------------
 [Please confirm]
 
 -------------------------------------------------------------------------------
-URL for a repo that contains the exact code which was built to get this binary:
+### URL for a repo that contains the exact code which was built to get this binary:
 -------------------------------------------------------------------------------
 [your url here]
 
 -------------------------------------------------------------------------------
-What patches are being applied and why:
+### What patches are being applied and why:
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-If bootloader, shim loading is, GRUB2: is CVE-2020-14372, CVE-2020-25632,
- CVE-2020-25647, CVE-2020-27749, CVE-2020-27779, CVE-2021-20225, CVE-2021-20233,
- CVE-2020-10713, CVE-2020-14308, CVE-2020-14309, CVE-2020-14310, CVE-2020-14311,
- CVE-2020-15705, and if you are shipping the shim_lock module CVE-2021-3418
+### If bootloader, shim loading is, GRUB2: is CVE-2020-14372, CVE-2020-25632, CVE-2020-25647, CVE-2020-27749, CVE-2020-27779, CVE-2021-20225, CVE-2021-20233, CVE-2020-10713, CVE-2020-14308, CVE-2020-14309, CVE-2020-14310, CVE-2020-14311, CVE-2020-15705, and if you are shipping the shim_lock module CVE-2021-3418
 -------------------------------------------------------------------------------
 [your text here]
 
 
 -------------------------------------------------------------------------------
-What exact implementation of Secureboot in GRUB2 ( if this is your bootloader ) you have ?
-* Upstream GRUB2 shim_lock verifier or * Downstream RHEL/Fedora/Debian/Canonical like implementation ?
+### What exact implementation of Secureboot in GRUB2 ( if this is your bootloader ) you have ?
+### * Upstream GRUB2 shim_lock verifier or * Downstream RHEL/Fedora/Debian/Canonical like implementation ?
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-If bootloader, shim loading is, GRUB2, and previous shims were trusting affected
-by CVE-2020-14372, CVE-2020-25632, CVE-2020-25647, CVE-2020-27749,
-  CVE-2020-27779, CVE-2021-20225, CVE-2021-20233, CVE-2020-10713,
-  CVE-2020-14308, CVE-2020-14309, CVE-2020-14310, CVE-2020-14311, CVE-2020-15705,
-  and if you were shipping the shim_lock module CVE-2021-3418
-  ( July 2020 grub2 CVE list + March 2021 grub2 CVE list )
-  grub2:
+### If bootloader, shim loading is, GRUB2, and previous shims were trusting affected by CVE-2020-14372, CVE-2020-25632, CVE-2020-25647, CVE-2020-27749, CVE-2020-27779, CVE-2021-20225, CVE-2021-20233, CVE-2020-10713, CVE-2020-14308, CVE-2020-14309, CVE-2020-14310, CVE-2020-14311, CVE-2020-15705, and if you were shipping the shim_lock module CVE-2021-3418 ( July 2020 grub2 CVE list + March 2021 grub2 CVE list ) grub2:
 * were old shims hashes provided to Microsoft for verification
   and to be added to future DBX update ?
 * Does your new chain of trust disallow booting old, affected by CVE-2020-14372,
@@ -111,43 +99,35 @@ by CVE-2020-14372, CVE-2020-25632, CVE-2020-25647, CVE-2020-27749,
 [your text here]
 
 -------------------------------------------------------------------------------
-If your boot chain of trust includes linux kernel, is
-"efi: Restrict efivar_ssdt_load when the kernel is locked down"
-upstream commit 1957a85b0032a81e6482ca4aab883643b8dae06e applied ?
-Is "ACPI: configfs: Disallow loading ACPI tables when locked down"
-upstream commit 75b0cea7bf307f362057cc778efe89af4c615354 applied ?
+### If your boot chain of trust includes linux kernel, is "efi: Restrict efivar_ssdt_load when the kernel is locked down" upstream commit 1957a85b0032a81e6482ca4aab883643b8dae06e applied ?
+### Is "ACPI: configfs: Disallow loading ACPI tables when locked down" upstream commit 75b0cea7bf307f362057cc778efe89af4c615354 applied ?
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-If you use vendor_db functionality of providing multiple certificates and/or
-hashes please briefly describe your certificate setup. If there are allow-listed hashes
-please provide exact binaries for which hashes are created via file sharing service,
-available in public with anonymous access for verification
+### If you use vendor_db functionality of providing multiple certificates and/or hashes please briefly describe your certificate setup. 
+### If there are allow-listed hashes please provide exact binaries for which hashes are created via file sharing service, available in public with anonymous access for verification
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-If you are re-using a previously used (CA) certificate, you will need
-to add the hashes of the previous GRUB2 binaries to vendor_dbx in shim
-in order to prevent GRUB2 from being able to chainload those older GRUB2
-binaries. If you are changing to a new (CA) certificate, this does not
-apply. Please describe your strategy.
+### If you are re-using a previously used (CA) certificate, you will need to add the hashes of the previous GRUB2 binaries to vendor_dbx in shim in order to prevent GRUB2 from being able to chainload those older GRUB2 binaries. If you are changing to a new (CA) certificate, this does not apply. 
+### Please describe your strategy.
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-What OS and toolchain must we use to reproduce this build?  Include where to find it, etc.  We're going to try to reproduce your build as close as possible to verify that it's really a build of the source tree you tell us it is, so these need to be fairly thorough. At the very least include the specific versions of gcc, binutils, and gnu-efi which were used, and where to find those binaries.
-If the shim binaries can't be reproduced using the provided Dockerfile, please explain why that's the case and what the differences would be.
+### What OS and toolchain must we use to reproduce this build?  Include where to find it, etc.  We're going to try to reproduce your build as close as possible to verify that it's really a build of the source tree you tell us it is, so these need to be fairly thorough. At the very least include the specific versions of gcc, binutils, and gnu-efi which were used, and where to find those binaries.
+### If the shim binaries can't be reproduced using the provided Dockerfile, please explain why that's the case and what the differences would be.
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-Which files in this repo are the logs for your build?   This should include logs for creating the buildroots, applying patches, doing the build, creating the archives, etc.
+### Which files in this repo are the logs for your build?   This should include logs for creating the buildroots, applying patches, doing the build, creating the archives, etc.
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-Add any additional information you think we may need to validate this shim
+### Add any additional information you think we may need to validate this shim
 -------------------------------------------------------------------------------
 [your text here]

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ your part.
 Here's the template:
 
 -------------------------------------------------------------------------------
-### What organization or people are asking to have this signed:
+### What organization or people are asking to have this signed?
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### What product or service is this for:
+### What product or service is this for?
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### What's the justification that this really does need to be signed for the whole world to be able to boot it:
+### What's the justification that this really does need to be signed for the whole world to be able to boot it?
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### Who is the primary contact for security updates, etc.
+### Who is the primary contact for security updates, etc.?
 -------------------------------------------------------------------------------
 - Name:
 - Position:
@@ -45,7 +45,7 @@ like keyserver.ubuntu.com, and preferably have signatures that are reasonably
 well known in the Linux community.)
 
 -------------------------------------------------------------------------------
-### Who is the secondary contact for security updates, etc.
+### Who is the secondary contact for security updates, etc.?
 -------------------------------------------------------------------------------
 - Name:
 - Position:
@@ -99,35 +99,38 @@ well known in the Linux community.)
 [your text here]
 
 -------------------------------------------------------------------------------
-### If your boot chain of trust includes linux kernel, is "efi: Restrict efivar_ssdt_load when the kernel is locked down" upstream commit 1957a85b0032a81e6482ca4aab883643b8dae06e applied ?
-### Is "ACPI: configfs: Disallow loading ACPI tables when locked down" upstream commit 75b0cea7bf307f362057cc778efe89af4c615354 applied ?
+### If your boot chain of trust includes a linux kernel:
+### Is upstream commit [1957a85b0032a81e6482ca4aab883643b8dae06e "efi: Restrict efivar_ssdt_load when the kernel is locked down"](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1957a85b0032a81e6482ca4aab883643b8dae06e) applied?
+### Is upstream commit [75b0cea7bf307f362057cc778efe89af4c615354 "ACPI: configfs: Disallow loading ACPI tables when locked down"](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=75b0cea7bf307f362057cc778efe89af4c615354) applied?
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### If you use vendor_db functionality of providing multiple certificates and/or hashes please briefly describe your certificate setup. 
-### If there are allow-listed hashes please provide exact binaries for which hashes are created via file sharing service, available in public with anonymous access for verification
+### If you use vendor_db functionality of providing multiple certificates and/or hashes please briefly describe your certificate setup.
+### If there are allow-listed hashes please provide exact binaries for which hashes are created via file sharing service, available in public with anonymous access for verification.
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### If you are re-using a previously used (CA) certificate, you will need to add the hashes of the previous GRUB2 binaries to vendor_dbx in shim in order to prevent GRUB2 from being able to chainload those older GRUB2 binaries. If you are changing to a new (CA) certificate, this does not apply. 
+### If you are re-using a previously used (CA) certificate, you will need to add the hashes of the previous GRUB2 binaries exposed to the CVEs to vendor_dbx in shim in order to prevent GRUB2 from being able to chainload those older GRUB2 binaries. If you are changing to a new (CA) certificate, this does not apply.
 ### Please describe your strategy.
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### What OS and toolchain must we use to reproduce this build?  Include where to find it, etc.  We're going to try to reproduce your build as close as possible to verify that it's really a build of the source tree you tell us it is, so these need to be fairly thorough. At the very least include the specific versions of gcc, binutils, and gnu-efi which were used, and where to find those binaries.
+### What OS and toolchain must we use to reproduce this build?  Include where to find it, etc.  We're going to try to reproduce your build as closely as possible to verify that it's really a build of the source tree you tell us it is, so these need to be fairly thorough. At the very least include the specific versions of gcc, binutils, and gnu-efi which were used, and where to find those binaries.
 ### If the shim binaries can't be reproduced using the provided Dockerfile, please explain why that's the case and what the differences would be.
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### Which files in this repo are the logs for your build?   This should include logs for creating the buildroots, applying patches, doing the build, creating the archives, etc.
+### Which files in this repo are the logs for your build?
+This should include logs for creating the buildroots, applying patches, doing the build, creating the archives, etc.
+
 -------------------------------------------------------------------------------
 [your text here]
 
 -------------------------------------------------------------------------------
-### Add any additional information you think we may need to validate this shim
+### Add any additional information you think we may need to validate this shim.
 -------------------------------------------------------------------------------
 [your text here]


### PR DESCRIPTION
This changes the headers and horizontal rules to be the same style in both documents.

There are two goals:
* Make it a little easier for submitters to copy answers from README  (where the docs ask us to commit them) to the github issue
* Hopefully make it easier for maintainers to update the questions, since there's now only one format to match

I chose this style in an attempt to capture the benefits of each of the styles currently in use.
* README was using a [horizontal rule](https://daringfireball.net/projects/markdown/syntax#hr) (`---`) before a [setext-style header](https://daringfireball.net/projects/markdown/syntax#header) (also `---`). Github seems to format that nicely until you try to have a list in there (see the two questions after [this](https://github.com/rhboot/shim-review/blob/d2f40a40f281d5ae482dfa7cc73ac11fd187e182/README.md#if-bootloader-shim-loading-is-grub2-is-cve-2020-14372-cve-2020-25632cve-2020-25647-cve-2020-27749-cve-2020-27779-cve-2021-20225-cve-2021-20233cve-2020-10713-cve-2020-14308-cve-2020-14309-cve-2020-14310-cve-2020-14311cve-2020-15705-and-if-you-are-shipping-the-shim_lock-module-cve-2021-3418) one).
* ISSUE_TEMPLATE was using [atx-style headers](https://daringfireball.net/projects/markdown/syntax#header), but seems to vary between `#####` and `######`, probably because it's hard to spot the difference at a glance.

I'm standardizing on the combination of `###` to indicate which lines to header-ify (It's easier to spot the difference between
`##` and `###` or `###` and `####` than to spot the difference between `####` and `#####` or `#####` and `######`) along with horizontal rules (`---`) to box in lists and other non-header text, since lists don't work in headers.

This was originally posted as part of https://github.com/rhboot/shim-review/pull/207. I'm attempting to break out individual commits from that PR.

### For example:
![image](https://user-images.githubusercontent.com/1101979/135333999-76abfdf4-0101-4368-8a39-0cd9a18e46ed.png)
becomes 
![image](https://user-images.githubusercontent.com/1101979/135334958-8b8ed60c-9283-4445-8f73-01dab89002bd.png)

and 
![image](https://user-images.githubusercontent.com/1101979/135336216-fb1a7ce2-3a7a-4f63-88ae-fec7ab50abb2.png)
becomes
![image](https://user-images.githubusercontent.com/1101979/135336159-fc6d71d5-ee50-4732-8af5-7d02f68ff353.png)
