### PR TITLE
README: make formatting more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ This matches https://github.com/rhboot/shim/releases/tag/15.7 and contains the a
 
 -------------------------------------------------------------------------------
 ### If these fixes have been applied, have you set the global SBAT generation on your GRUB binary to 3?
-
 -------------------------------------------------------------------------------
 [your text here]
 
+-------------------------------------------------------------------------------
 ### Were old shims hashes provided to Microsoft for verification and to be added to future DBX updates?
 ### Does your new chain of trust disallow booting old GRUB2 builds affected by the CVEs?
 -------------------------------------------------------------------------------
@@ -138,7 +138,6 @@ This matches https://github.com/rhboot/shim/releases/tag/15.7 and contains the a
 ### Is upstream commit [1957a85b0032a81e6482ca4aab883643b8dae06e "efi: Restrict efivar_ssdt_load when the kernel is locked down"](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1957a85b0032a81e6482ca4aab883643b8dae06e) applied?
 ### Is upstream commit [75b0cea7bf307f362057cc778efe89af4c615354 "ACPI: configfs: Disallow loading ACPI tables when locked down"](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=75b0cea7bf307f362057cc778efe89af4c615354) applied?
 ### Is upstream commit [eadb2f47a3ced5c64b23b90fd2a3463f63726066 "lockdown: also lock down previous kgdb use"](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=eadb2f47a3ced5c64b23b90fd2a3463f63726066) applied?
-
 -------------------------------------------------------------------------------
 [your text here]
 
@@ -168,7 +167,6 @@ This matches https://github.com/rhboot/shim/releases/tag/15.7 and contains the a
 -------------------------------------------------------------------------------
 ### Which files in this repo are the logs for your build?
 This should include logs for creating the buildroots, applying patches, doing the build, creating the archives, etc.
-
 -------------------------------------------------------------------------------
 [your text here]
 


### PR DESCRIPTION
On a few questions the `---` separators were missing or placed differently.