### PR TITLE
Add cross-review question

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -23,3 +23,8 @@ Confirm the following are included in your repo, checking each box:
 ### What is the link to your previous shim review request (if any, otherwise N/A)?
 -------------------------------------------------------------------------------
 [your text here]
+
+-------------------------------------------------------------------------------
+### Has your organization recently reviewed at least one other submission?
+-------------------------------------------------------------------------------
+[your text here]


### PR DESCRIPTION
shim-review is meant to be distros reviewing each other and right now it's very much not.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>