### PR TITLE
Add question about how kernel modules are signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ This matches https://github.com/rhboot/shim/releases/tag/15.7 and contains the a
 [your text here]
 
 *******************************************************************************
+### Do you use an ephemeral key for signing kernel modules?
+### If not, please describe how you ensure that one kernel build does not load modules built for another kernel.
+*******************************************************************************
+[your text here]
+
+*******************************************************************************
 ### If you use vendor_db functionality of providing multiple certificates and/or hashes please briefly describe your certificate setup.
 ### If there are allow-listed hashes please provide exact binaries for which hashes are created via file sharing service, available in public with anonymous access for verification.
 *******************************************************************************


### PR DESCRIPTION
At least Debian is currently signing modules with the same key as the kernel, causing the kernel to be able to load modules not intended for it, potentially causing grave security issues. This is violating the security model, so let's make sure nobody does stuff like that anymore.