### PR TITLE
Ask about the NX bit and point to NX signing exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ This matches https://github.com/rhboot/shim/releases/tag/15.7 and contains the a
 [your text here]
 
 *******************************************************************************
+### Do you have the NX bit set in your shim? If so, is your entire boot stack NX-compatible and what testing have you done to ensure such compatibility?
+
+See https://techcommunity.microsoft.com/t5/hardware-dev-center/nx-exception-for-shim-community/ba-p/3976522 for more details on the signing of shim without NX bit.
+*******************************************************************************
+[your text here]
+
+*******************************************************************************
 ### If shim is loading GRUB2 bootloader what exact implementation of Secureboot in GRUB2 do you have? (Either Upstream GRUB2 shim_lock verifier or Downstream RHEL/Fedora/Debian/Canonical-like implementation)
 *******************************************************************************
 [your text here]


### PR DESCRIPTION
Microsoft issued an exception for signing shims without NX bits set. As reviewers should be aware already, shims should only be signed with the NX bit on if the entire boot stack is NX compatible. The final kernel support landed in 6.7 mainline AFAIUI, and the grub work still remains a bit WIP.

But let's ask people specifically about this, and if they do submit NX shim to explain what testing they did to ensure compliance. Not everyone uses grub and their loaders may be NX-compatible and they might have kernels ready now if they're bleeding edge.