### PR TITLE
Guidelines: add examples for UKI .sbat section

### DIFF
--- a/docs/reviewer-guidelines.md
+++ b/docs/reviewer-guidelines.md
@@ -183,14 +183,30 @@ If systemd-boot is used:
    Type #1 or Type #2 third stages, or either?
 1. Is it the minimum required version, or alternatively does it have
    the patches stated by the issue template and README.md, if any?
-1. Does it include the appropriate SBAT metadata, and is the identifier
-   separate from systemd-stub (if used, i.e.: Type #2 BLS)?
+1. Does it include the appropriate SBAT metadata, and if Type #2 BLS
+   (i.e.: UKIs) are used, are the identifiers of systemd-boot and
+   systemd-stub (UKI/kernel.efi) separate and distinct (examples after
+   the list)?
 1. Are there any custom patches applied?  If so, are they explained by
    the submitter and well understood? This can be **very**
    time-consuming to do right - if a vendor is doing their own novel
    patches we may need to get more reviews.
 1. For more information about systemd-boot's security posture, please
    consult [its documentation](https://github.com/systemd/systemd/blob/main/src/boot/efi/UEFI_SECURITY.md).
+
+Example of the .sbat entry of a systemd-boot binary:
+```
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+systemd-boot,1,The systemd Developers,systemd,255,https://systemd.io/
+systemd-boot.debian,1,Debian GNU/Linux,systemd,255-1,https://bugs.debian.org/
+```
+
+Example of the .sbat entry of a UKI:
+```
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+systemd-stub,1,The systemd Developers,systemd,255,https://systemd.io/
+systemd-stub.debian,1,Debian GNU/Linux,systemd,255-1,https://bugs.debian.org/
+```
 
 ## Alternative second-stage bootloaders
 


### PR DESCRIPTION
The .sbat identifier of systemd-boot was split from the identifier of systemd-stub (which is used by UKI/kernel.efi binaries) after the previous release, so clarify this with concrete examples.