### PR TITLE
Request a link to an application with verified contacts

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -23,3 +23,8 @@ Confirm the following are included in your repo, checking each box:
 ### What is the link to your previous shim review request (if any, otherwise N/A)?
 *******************************************************************************
 [your text here]
+
+*******************************************************************************
+### If no security contacts have changed since verification, what is the link to your request, where they've been verified (if any, otherwise N/A)?
+*******************************************************************************
+[your text here]


### PR DESCRIPTION
If security contacts have already been verified in an earlier application and haven't changed since the current one, let's point to that earlier application as part of the current one.