### PR TITLE
Update objcopy command to work when ALLOC is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ If you are using a downstream implementation of GRUB2 (e.g. from Fedora or Debia
 
 **Remember to post the entries of all the binaries. Apart from your bootloader, you may also be shipping e.g. a firmware updater, which will also have these.**
 
-Hint: run `objcopy --only-section .sbat -O binary YOUR_EFI_BINARY /dev/stdout` to get these entries. Paste them here. Preferably surround each listing with three backticks (\`\`\`), so they render well.
+Hint: run `objcopy --dump-section .sbat=/dev/stdout YOUR_EFI_BINARY` to get these entries. Paste them here. Preferably surround each listing with three backticks (\`\`\`), so they render well.
 *******************************************************************************
 [your text here]
 


### PR DESCRIPTION
The binary output mode of objcopy only copies sections with the ALLOC flag set. There is no requirement to have the ALLOC flag set for the .sbat section so update the objcopy command to a variant that works for both cases.