### PR TITLE
docs: Update link to systemd-boot's security posture

### DIFF
--- a/docs/reviewer-guidelines.md
+++ b/docs/reviewer-guidelines.md
@@ -193,7 +193,7 @@ If systemd-boot is used:
    time-consuming to do right - if a vendor is doing their own novel
    patches we may need to get more reviews.
 1. For more information about systemd-boot's security posture, please
-   consult [its documentation](https://github.com/systemd/systemd/blob/main/src/boot/efi/UEFI_SECURITY.md).
+   consult [its documentation](https://github.com/systemd/systemd/blob/main/src/boot/UEFI_SECURITY.md).
 
 Example of the .sbat entry of a systemd-boot binary:
 ```


### PR DESCRIPTION
Updates: https://github.com/rhboot/shim-review/pull/357
See: https://github.com/systemd/systemd/commit/97318131fd06a5bc35454da81dcbbc84f16d9940
See: https://github.com/systemd/systemd/blob/main/src/boot/UEFI_SECURITY.md